### PR TITLE
Amend all imports to use absolute imports

### DIFF
--- a/atmcorr/atmcorr_timeseries.py
+++ b/atmcorr/atmcorr_timeseries.py
@@ -9,7 +9,7 @@ correction)
 """
 
 import math
-import mission_specifics
+import atmcorr.mission_specifics as mission_s
 
 def atmcorr(radiance, perihelion, day_of_year):
   """
@@ -42,8 +42,8 @@ def surface_reflectance_timeseries(meanRadiance, iLUTs, mission):
   feature_collection = meanRadiance['features']
   
   # band names 
-  ee_bandnames = mission_specifics.ee_bandnames(mission)
-  py6s_bandnames = mission_specifics.py6s_bandnames(mission)
+  ee_bandnames = mission_s.ee_bandnames(mission)
+  py6s_bandnames = mission_s.py6s_bandnames(mission)
 
   # time series output variable
   timeSeries = {'timeStamp':[], 'mission':mission}

--- a/atmcorr/ee_requests.py
+++ b/atmcorr/ee_requests.py
@@ -12,9 +12,9 @@ Returns a feature collection which could be input into, for exampled:
 """
 
 import ee
-from atmospheric import Atmospheric
-from cloudRemover import CloudRemover
-import mission_specifics
+from atmcorr.atmospheric import Atmospheric
+from atmcorr.cloudRemover import CloudRemover
+import atmcorr.mission_specifics as mission_s
 
 class AtmcorrInput:
   """
@@ -32,7 +32,7 @@ class AtmcorrInput:
         )
 
     return ee.Dictionary({
-      'solar_z':mission_specifics.solar_z(TimeSeries.image, TimeSeries.mission),
+      'solar_z':mission_s.solar_z(TimeSeries.image, TimeSeries.mission),
       'h2o':Atmospheric.water(TimeSeries.geom,TimeSeries.date),
       'o3':Atmospheric.ozone(TimeSeries.geom,TimeSeries.date),
       'aot':Atmospheric.aerosol(TimeSeries.geom,TimeSeries.date),
@@ -65,16 +65,16 @@ class TimeSeries:
     """
 
     # top of atmosphere reflectance
-    toa = mission_specifics.TOA(TimeSeries.image, TimeSeries.mission)
+    toa = mission_s.TOA(TimeSeries.image, TimeSeries.mission)
 
     # solar irradiances
-    ESUNs = mission_specifics.ESUNs(TimeSeries.image, TimeSeries.mission)
+    ESUNs = mission_s.ESUNs(TimeSeries.image, TimeSeries.mission)
 
     # wavebands
-    bands = mission_specifics.ee_bandnames(TimeSeries.mission)
+    bands = mission_s.ee_bandnames(TimeSeries.mission)
 
     # solar zenith (radians)
-    theta = mission_specifics.solar_z(TimeSeries.image, TimeSeries.mission).multiply(0.017453293)
+    theta = mission_s.solar_z(TimeSeries.image, TimeSeries.mission).multiply(0.017453293)
 
     # circular math
     pi = ee.Number(3.14159265359)
@@ -141,9 +141,9 @@ def request_meanRadiance(geom, startDate, stopDate, mission, removeClouds):
   TimeSeries.cloudRemover = CloudRemover  
 
   # Earth Engine image collection
-  ic = ee.ImageCollection(mission_specifics.eeCollection(mission))\
+  ic = ee.ImageCollection(mission_s.eeCollection(mission))\
     .filterBounds(geom)\
     .filterDate(startDate, stopDate)\
-    .filter(mission_specifics.sunAngleFilter(mission))
+    .filter(mission_s.sunAngleFilter(mission))
 
   return ic.map(TimeSeries.extractor).sort('timestamp')

--- a/atmcorr/interpolated_lookup_tables.py
+++ b/atmcorr/interpolated_lookup_tables.py
@@ -16,7 +16,7 @@ import zipfile
 import time
 from itertools import product
 from scipy.interpolate import LinearNDInterpolator
-import mission_specifics
+import atmcorr.mission_specifics as mission_s
 
 class handler:
   """
@@ -34,7 +34,7 @@ class handler:
     self.bin_path = os.path.dirname(os.path.abspath(__file__))
     self.base_path = os.path.dirname(self.bin_path)
     self.files_path = os.path.join(self.base_path,'files')
-    self.py6S_sensor = mission_specifics.py6S_sensor(self.mission)
+    self.py6S_sensor = mission_s.py6S_sensor(self.mission)
     self.LUT_path = os.path.join(self.files_path,'LUTs',self.py6S_sensor,\
         'Continental','view_zenith_0')
     self.iLUT_path = os.path.join(self.files_path,'iLUTs',self.py6S_sensor,\

--- a/atmcorr/timeSeries.py
+++ b/atmcorr/timeSeries.py
@@ -1,11 +1,11 @@
 import os
 import ee
 import pandas as pd
-import interpolated_lookup_tables as iLUT
-from ee_requests import request_meanRadiance
-from atmcorr_timeseries import surface_reflectance_timeseries
-from mission_specifics import ee_bandnames
-from mission_specifics import common_bandnames
+
+import atmcorr.interpolated_lookup_tables as iLUT
+from atmcorr.ee_requests import request_meanRadiance
+from atmcorr.atmcorr_timeseries import surface_reflectance_timeseries
+from atmcorr.mission_specifics import ee_bandnames, common_bandnames
 
 def timeseries_extrator(geom, startDate, stopDate, mission, removeClouds=True):
     """

--- a/ee-atmcorr-timeseries.ipynb
+++ b/ee-atmcorr-timeseries.ipynb
@@ -57,11 +57,11 @@
     "ee.Initialize()\n",
     "\n",
     "# custom modules\n",
-    "base_dir = os.path.dirname(os.getcwd())\n",
-    "sys.path.append(os.path.join(base_dir,'atmcorr'))\n",
-    "from timeSeries import timeSeries\n",
-    "from postProcessing import postProcessing\n",
-    "from plots import plotTimeSeries"
+    "# base_dir = os.path.dirname(os.getcwd())\n",
+    "# sys.path.append(os.path.join(base_dir,'atmcorr'))\n",
+    "from atmcorr.timeSeries import timeSeries\n",
+    "from atmcorr.postProcessing import postProcessing\n",
+    "from atmcorr.plots import plotTimeSeries"
    ]
   },
   {


### PR DESCRIPTION
This amends all in-package imports to use the absolute import system following PEP 328. This way, sys.path hacks are unnecessary. I had to move the jupyter notebook to the root of the repo, because it can't import a package from the parent directory. Please merge this pull request along with #5 as #5 will not work independently.